### PR TITLE
docker: cleanup Dockerfile and docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,24 +14,13 @@ COPY pyproject.toml poetry.lock ./
 
 RUN poetry config virtualenvs.create false && poetry install --only main --no-root
 
-COPY dnd_helper dnd_helper
-
 FROM python:3.11-slim
 
 # Устанавливаем рабочую директорию
 WORKDIR /app
-
-# Копируем исходный код и зависимости из предыдущего этапа
-COPY --from=builder /build/dnd_helper ./dnd_helper
-COPY --from=builder /build/pyproject.toml ./pyproject.toml
-COPY --from=builder /build/poetry.lock ./poetry.lock
-
-# Копируем зависимости (site-packages) из сборочного образа
-COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
-COPY --from=builder /usr/local/bin/poetry /usr/local/bin/poetry
-
 # Устанавливаем PYTHONPATH, чтобы импорты работали корректно
 ENV PYTHONPATH=/app
 
-# Запускаем приложение
-CMD ["python", "dnd_helper/main.py"]
+# Копируем зависимости (site-packages) из сборочного образа
+COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ To deploy the application using Docker Compose:
 3. Run the application using Docker Compose:
 
    ```bash
-   docker build -t my_dnd_bot:0.6.0 .
    docker-compose up -d
    ```
    

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,12 @@
 services:
   app:
-    image: my_dnd_bot:0.6.0
+    image: my_dnd_bot
+    build: "."
     restart: unless-stopped
     volumes:
       - db-data:/app/db
+      - ./dnd_helper:/app/dnd_helper
+    entrypoint: python dnd_helper/main.py
 
 volumes:
   db-data:


### PR DESCRIPTION
Mount source code as a volume, instead of copying source directly to image. In such a way, we won't need to rebuild docker image with each app new version, but only on dependency update. Also, docker image now can be used for development.

Move entrypoint to docker-compose because depends on source code, which is now mounted, not directly included.